### PR TITLE
Group membership privacy

### DIFF
--- a/wp-content/themes/openlab/buddypress/groups/groups-loop.php
+++ b/wp-content/themes/openlab/buddypress/groups/groups-loop.php
@@ -272,7 +272,7 @@ if( ! bp_is_my_profile() && ! current_user_can( 'bp_moderate' ) ) {
 								<p class="truncate-on-the-fly" data-basevalue="105" data-basewidth="250"><?php echo bp_get_group_description_excerpt() ?></p>
 							</div>
 
-							<?php if( current_user_can( 'bp_moderate' ) && in_array( $group_id, $private_groups ) ) { ?>
+							<?php if( current_user_can( 'bp_moderate' ) && in_array( $group_id, $private_groups, true ) ) { ?>
 							<p class="private-membership-indicator"><span class="fa fa-eye-slash"></span> Membership hidden</p>
 							<?php } ?>
 						</div>

--- a/wp-content/themes/openlab/buddypress/groups/groups-loop.php
+++ b/wp-content/themes/openlab/buddypress/groups/groups-loop.php
@@ -10,6 +10,8 @@ $group_args = array(
 	'type'         => $group_sort,
 );
 
+$user_id = bp_displayed_user_id();
+
 $filters = array();
 if ( bp_is_user_groups() ) {
 	if ( isset( $_GET['type'] ) && in_array( $_GET['type'], openlab_group_types(), true ) ) {
@@ -18,7 +20,7 @@ if ( bp_is_user_groups() ) {
 		$group_type = 'course';
 	}
 
-	$group_args['user_id'] = bp_displayed_user_id();
+	$group_args['user_id'] = $user_id;
 } elseif ( openlab_is_search_results_page() ) {
 	$group_type = openlab_get_current_filter( 'group-types' );
 	if ( ! $group_type ) {
@@ -158,6 +160,13 @@ if ( $ancestor_of ) {
 	);
 }
 
+// Get private groups of the user
+$private_groups = openlab_get_user_private_membership( $user_id );
+
+// Exclude private groups if not current user's profile or don't have moderate access.
+if( ! bp_is_my_profile() && ! current_user_can( 'moderate' ) ) {
+	$group_args['exclude'] = $private_groups;
+}
 ?>
 
 <?php if ( bp_has_groups( $group_args ) ) : ?>
@@ -262,6 +271,10 @@ if ( $ancestor_of ) {
 							<div class="description-line">
 								<p class="truncate-on-the-fly" data-basevalue="105" data-basewidth="250"><?php echo bp_get_group_description_excerpt() ?></p>
 							</div>
+
+							<?php if( current_user_can( 'moderate' ) && in_array( $group_id, $private_groups ) ) { ?>
+							<p class="private-membership-indicator"><span class="fa fa-eye-slash"></span> Membership hidden</p>
+							<?php } ?>
 						</div>
 					</div><!--item-->
 

--- a/wp-content/themes/openlab/buddypress/groups/groups-loop.php
+++ b/wp-content/themes/openlab/buddypress/groups/groups-loop.php
@@ -164,7 +164,7 @@ if ( $ancestor_of ) {
 $private_groups = openlab_get_user_private_membership( $user_id );
 
 // Exclude private groups if not current user's profile or don't have moderate access.
-if( ! bp_is_my_profile() && ! current_user_can( 'moderate' ) ) {
+if( ! bp_is_my_profile() && ! current_user_can( 'bp_moderate' ) ) {
 	$group_args['exclude'] = $private_groups;
 }
 ?>
@@ -272,7 +272,7 @@ if( ! bp_is_my_profile() && ! current_user_can( 'moderate' ) ) {
 								<p class="truncate-on-the-fly" data-basevalue="105" data-basewidth="250"><?php echo bp_get_group_description_excerpt() ?></p>
 							</div>
 
-							<?php if( current_user_can( 'moderate' ) && in_array( $group_id, $private_groups ) ) { ?>
+							<?php if( current_user_can( 'bp_moderate' ) && in_array( $group_id, $private_groups ) ) { ?>
 							<p class="private-membership-indicator"><span class="fa fa-eye-slash"></span> Membership hidden</p>
 							<?php } ?>
 						</div>

--- a/wp-content/themes/openlab/buddypress/groups/single/members.php
+++ b/wp-content/themes/openlab/buddypress/groups/single/members.php
@@ -29,6 +29,16 @@
                                                 <a class="no-deco truncate-on-the-fly hyphenate" href="<?php bp_member_permalink() ?>" data-basevalue="28" data-minvalue="20" data-basewidth="152"><?php bp_member_name(); ?></a><span class="original-copy hidden"><?php bp_member_name(); ?></span>
                                             </p>
 				<span class="activity"><?php openlab_member_joined_since() ?></span>
+				
+				<?php 
+				// Show "Hide my membership" checkbox for the current user
+				if( bp_get_member_user_id() === bp_loggedin_user_id() ) { ?>
+				<div class="group-item-membership-privacy">
+					<label>
+						<input type="checkbox" name="membership_privacy" id="membership_privacy" data-group_id="<?php echo bp_get_current_group_id(); ?>" value="<?php echo bp_loggedin_user_id(); ?>" /> Hide my membership
+					</label>
+				</div>
+				<?php } ?>
 
 				<?php do_action( 'bp_group_members_list_item' ) ?>
 

--- a/wp-content/themes/openlab/buddypress/groups/single/members.php
+++ b/wp-content/themes/openlab/buddypress/groups/single/members.php
@@ -31,11 +31,14 @@
 				<span class="activity"><?php openlab_member_joined_since() ?></span>
 				
 				<?php 
-				// Show "Hide my membership" checkbox for the current user
+				// Check if current user's membership is private for this group.
+				$isPrivate = openlab_is_my_membership_private( bp_get_current_group_id() );
+
+				// Show "Hide my membership" checkbox for the logged in user only
 				if( bp_get_member_user_id() === bp_loggedin_user_id() ) { ?>
 				<div class="group-item-membership-privacy">
 					<label>
-						<input type="checkbox" name="membership_privacy" id="membership_privacy" data-group_id="<?php echo bp_get_current_group_id(); ?>" value="<?php echo bp_loggedin_user_id(); ?>" /> Hide my membership
+						<input type="checkbox" name="membership_privacy" id="membership_privacy" data-group_id="<?php echo bp_get_current_group_id(); ?>" value="<?php echo bp_loggedin_user_id(); ?>" <?php echo ( $isPrivate ) ? 'checked' : ''; ?> /> Hide my membership
 					</label>
 				</div>
 				<?php } ?>

--- a/wp-content/themes/openlab/buddypress/groups/single/members.php
+++ b/wp-content/themes/openlab/buddypress/groups/single/members.php
@@ -3,7 +3,7 @@
 $private_users = openlab_get_group_private_users( bp_get_group_id() );
 
 // If user is not mod and there are private users, exclude them from the list
-if( ! current_user_can( 'moderate' ) && ! empty( $private_users ) ) {
+if( ! current_user_can( 'bp_moderate' ) && ! empty( $private_users ) ) {
 	$members_args['exclude'] = $private_users;
 }
 
@@ -44,7 +44,7 @@ if ( bp_group_has_members( $members_args ) ) : ?>
 				
 				<?php 
 				// Show "Hide my membership" checkbox for the logged in user and non-mods only
-				if( ( bp_get_member_user_id() === bp_loggedin_user_id() ) && ! current_user_can( 'moderate' ) ) { 
+				if( ( bp_get_member_user_id() === bp_loggedin_user_id() ) && ! current_user_can( 'bp_moderate' ) ) { 
 
 					// Check if current user's membership is private for this group.
 					$isPrivate = openlab_is_my_membership_private( bp_get_current_group_id() );	
@@ -57,7 +57,7 @@ if ( bp_group_has_members( $members_args ) ) : ?>
 				<?php } ?>
 				<?php 
 				// Show hidden membership label for the mods
-				if( current_user_can( 'moderate' ) && in_array( bp_get_member_user_id(), $private_users ) ) { ?>
+				if( current_user_can( 'bp_moderate' ) && in_array( bp_get_member_user_id(), $private_users ) ) { ?>
 				<p class="private-membership-indicator"><span class="fa fa-eye-slash"></span> Membership hidden</p>
 				<?php } ?>
 

--- a/wp-content/themes/openlab/buddypress/groups/single/members.php
+++ b/wp-content/themes/openlab/buddypress/groups/single/members.php
@@ -57,7 +57,7 @@ if ( bp_group_has_members( $members_args ) ) : ?>
 				<?php } ?>
 				<?php 
 				// Show hidden membership label for the mods
-				if( current_user_can( 'bp_moderate' ) && in_array( bp_get_member_user_id(), $private_users ) ) { ?>
+				if( current_user_can( 'bp_moderate' ) && in_array( bp_get_member_user_id(), $private_users, true ) ) { ?>
 				<p class="private-membership-indicator"><span class="fa fa-eye-slash"></span> Membership hidden</p>
 				<?php } ?>
 

--- a/wp-content/themes/openlab/functions.php
+++ b/wp-content/themes/openlab/functions.php
@@ -119,6 +119,13 @@ function openlab_load_scripts() {
     }
 
     wp_enqueue_script( 'openlab-group-documents', $stylesheet_dir_uri . '/js/group-documents.js', [ 'jquery' ] );
+
+    if( bp_is_group() ) {
+        wp_enqueue_script( 'openlab-group-membership', $stylesheet_dir_uri . '/js/membership-privacy.js', [ 'jquery' ] );
+        wp_localize_script( 'openlab-group-membership', 'membershipVars', array(
+            'ajax_url'  => admin_url( 'admin-ajax.php' )
+        ) );
+    }
 }
 
 add_action('wp_enqueue_scripts', 'openlab_load_scripts');

--- a/wp-content/themes/openlab/js/membership-privacy.js
+++ b/wp-content/themes/openlab/js/membership-privacy.js
@@ -1,0 +1,39 @@
+/**
+ * This is the JavaScript related to the membership privacy functionality.
+ * 
+ */
+
+ jQuery( document ).ready(
+	function($) {
+
+        $(document).on( 'change', 'input#membership_privacy', function(e) {
+            let groupId = $(this).attr('data-group_id');
+            let isPrivate = $(this).is(':checked');
+
+            $.ajax({
+                url: membershipVars.ajax_url,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    'action': 'openlab_update_member_group_privacy',
+                    'group_id': groupId,
+                    'is_private': isPrivate
+                },
+                beforeSend: function() {
+                    // Disable checkbox 
+                    $('input#membership_privacy').attr('disabled', true );
+                },
+                success: function( response ) {
+                    console.log( response );
+                    $('input#membership_privacy').attr('disabled', false );
+                },
+                complete: function() {
+                    $('input#membership_privacy').attr('disabled', false );
+                }
+            });
+
+        });
+        
+	},
+	(jQuery)
+);

--- a/wp-content/themes/openlab/js/membership-privacy.js
+++ b/wp-content/themes/openlab/js/membership-privacy.js
@@ -23,11 +23,8 @@
                     // Disable checkbox 
                     $('input#membership_privacy').attr('disabled', true );
                 },
-                success: function( response ) {
-                    console.log( response );
-                    $('input#membership_privacy').attr('disabled', false );
-                },
                 complete: function() {
+                    // Enable checkbox
                     $('input#membership_privacy').attr('disabled', false );
                 }
             });

--- a/wp-content/themes/openlab/lib/group-funcs.php
+++ b/wp-content/themes/openlab/lib/group-funcs.php
@@ -2093,7 +2093,7 @@ function openlab_get_group_private_users( $group_id ) {
 
 	if( $query ) {
 		foreach( $query as $item ) {
-			$private_users[] = $item->user_id;
+			$private_users[] = (int)$item->user_id;
 		}
 	}
 

--- a/wp-content/themes/openlab/lib/group-funcs.php
+++ b/wp-content/themes/openlab/lib/group-funcs.php
@@ -2073,3 +2073,29 @@ function openlab_group_type_disabled_filters() {
 
 	return $disabled;
 }
+
+/**
+ * Get group's private users
+ * 
+ */
+function openlab_get_group_private_users( $group_id ) {
+    // Skip if group id is missing
+    if( empty( $group_id ) ) {
+        return;
+    }
+
+	global $wpdb;
+	$table_name = $wpdb->prefix . 'private_membership';
+    $current_user_id = get_current_user_id();
+	$query = $wpdb->get_results( "SELECT `user_id` FROM $table_name WHERE `group_id` = $group_id AND `user_id` != $current_user_id", OBJECT_K);
+
+	$private_users = array();
+
+	if( $query ) {
+		foreach( $query as $item ) {
+			$private_users[] = $item->user_id;
+		}
+	}
+
+	return $private_users;
+}

--- a/wp-content/themes/openlab/lib/member-funcs.php
+++ b/wp-content/themes/openlab/lib/member-funcs.php
@@ -1545,11 +1545,8 @@ function openlab_update_member_group_privacy() {
 
 	// Check if group id is provded in the request
 	if( ! isset( $_POST['group_id'] ) ) {
-		echo json_encode( array(
-			'success'	=> false,
-			'message'	=> 'Group ID is missing.'
-		) );
-		die();
+		wp_send_json_error( 'Group ID is missing.' );
+		wp_die();
 	}
 
 	$group_id = $_POST['group_id'];
@@ -1557,27 +1554,18 @@ function openlab_update_member_group_privacy() {
 
 	if( $is_private ) {
 		if( $wpdb->insert( $table_name, array( 'user_id' => $user_id, 'group_id' => $group_id ) ) ) {
-			echo json_encode( array(
-				'success'	=> true,
-				'message'	=> 'User membership is set to private'
-			) );
-			die();
+			wp_send_json_success( 'User membership set to private.' );
+			wp_die();
 		}
 	} else {
 		if( $wpdb->delete( $table_name, array( 'user_id' => $user_id, 'group_id' => $group_id ) ) ) {
-			echo json_encode( array(
-				'success'	=> true,
-				'message'	=> 'User membership is set to public.'
-			) );
-			die();
+			wp_send_json_success( 'User membership set to public.' );
+			wp_die();
 		}
 	}
 
-	echo json_encode( array(
-		'success'	=> false,
-		'message'	=> 'Something went wrong'
-	) );
-	die();
+	wp_send_json_error( 'Something went wrong.' );
+	wp_die();
 }
 
 /**

--- a/wp-content/themes/openlab/lib/member-funcs.php
+++ b/wp-content/themes/openlab/lib/member-funcs.php
@@ -1595,21 +1595,3 @@ function openlab_is_my_membership_private( $group_id ) {
 
 	return false;
 }
-
-/**
- * Create table for storing the private membership
- * TODO: Create WP CLI command for this?
- */
-function openlab_create_private_membership_table() {
-	global $wpdb;
-	$charset = $wpdb->get_charset_collate();
-
-	$query = "CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}private_membership` (
-		`id` bigint(20) NOT NULL AUTO_INCREMENT,
-		`user_id` bigint(20) UNSIGNED NOT NULL,
-		`group_id` bigint(20) UNSIGNED NOT NULL,
-		PRIMARY KEY (id)
-	) $charset;";
-
-	$wpdb->query( $query );
-}

--- a/wp-content/themes/openlab/lib/member-funcs.php
+++ b/wp-content/themes/openlab/lib/member-funcs.php
@@ -1514,3 +1514,12 @@ function openlab_member_joined_since() {
 		date( 'F j, Y', strtotime( $members_template->member->date_modified ) )
 	);
 }
+
+/**
+ * Update user's list of private group membership.
+ * 
+ */
+add_action( 'wp_ajax_openlab_update_member_group_privacy', 'openlab_update_member_group_privacy' );
+function openlab_update_member_group_privacy() {
+	// TODO
+}

--- a/wp-content/themes/openlab/lib/member-funcs.php
+++ b/wp-content/themes/openlab/lib/member-funcs.php
@@ -689,7 +689,7 @@ function cuny_profile_activty_block( $type, $title, $last, $desc_length = 135 ) 
 										<p class="original-copy hidden"><?php echo $activity; ?></p>
 									</div>
 
-									<?php if( current_user_can( 'bp_moderate' ) && in_array( bp_get_group_id(), $private_groups ) ) { ?>
+									<?php if( current_user_can( 'bp_moderate' ) && in_array( bp_get_group_id(), $private_groups, true ) ) { ?>
 									<p class="private-membership-indicator"><span class="fa fa-eye-slash"></span> Membership hidden</p>
 									<?php } ?>
 
@@ -1616,7 +1616,7 @@ function openlab_get_user_private_membership( $user_id ) {
 
 	if( $query ) {
 		foreach( $query as $item ) {
-			$private_groups[] = $item->group_id;
+			$private_groups[] = (int)$item->group_id;
 		}
 	}
 

--- a/wp-content/themes/openlab/lib/member-funcs.php
+++ b/wp-content/themes/openlab/lib/member-funcs.php
@@ -632,7 +632,7 @@ function cuny_profile_activty_block( $type, $title, $last, $desc_length = 135 ) 
 		$exclude_groups = '';
 
 		// Exclude private groups if not current user's profile or don't have moderate access.
-		if( ! bp_is_my_profile() && ! current_user_can( 'moderate' ) ) {
+		if( ! bp_is_my_profile() && ! current_user_can( 'bp_moderate' ) ) {
 			$exclude_groups = '&exclude=' . implode(',', $private_groups);
 		}
 
@@ -689,7 +689,7 @@ function cuny_profile_activty_block( $type, $title, $last, $desc_length = 135 ) 
 										<p class="original-copy hidden"><?php echo $activity; ?></p>
 									</div>
 
-									<?php if( current_user_can( 'moderate' ) && in_array( bp_get_group_id(), $private_groups ) ) { ?>
+									<?php if( current_user_can( 'bp_moderate' ) && in_array( bp_get_group_id(), $private_groups ) ) { ?>
 									<p class="private-membership-indicator"><span class="fa fa-eye-slash"></span> Membership hidden</p>
 									<?php } ?>
 

--- a/wp-content/themes/openlab/lib/member-funcs.php
+++ b/wp-content/themes/openlab/lib/member-funcs.php
@@ -626,10 +626,20 @@ function cuny_profile_activty_block( $type, $title, $last, $desc_length = 135 ) 
 			'group_type'    => $type,
 			'get_activity'  => false,
 		);
+
+		// Get private groups of the user
+		$private_groups = openlab_get_user_private_membership( bp_displayed_user_id() );
+		$exclude_groups = '';
+
+		// Exclude private groups if not current user's profile or don't have moderate access.
+		if( ! bp_is_my_profile() && ! current_user_can( 'moderate' ) ) {
+			$exclude_groups = '&exclude=' . implode(',', $private_groups);
+		}
+
 		$groups         = openlab_get_groups_of_user( $get_group_args );
 
 		//echo $ids;
-		if ( ! empty( $groups['group_ids_sql'] ) && bp_has_groups( 'include=' . $groups['group_ids_sql'] . '&per_page=20' ) ) :
+		if ( ! empty( $groups['group_ids_sql'] ) && bp_has_groups( 'include=' . $groups['group_ids_sql'] . '&per_page=20' . $exclude_groups ) ) :
 			//    if ( bp_has_groups( 'include='.$ids.'&per_page=3&max=3' ) ) :
 			?>
 			<div id="<?php echo $type; ?>-activity-stream" class="<?php echo $type; ?>-list activity-list item-list<?php echo $last; ?> col-sm-8 col-xs-12">
@@ -678,6 +688,10 @@ function cuny_profile_activty_block( $type, $title, $last, $desc_length = 135 ) 
 										<p class="truncate-on-the-fly hyphenate" data-link="<?php echo bp_get_group_permalink(); ?>" data-includename="<?php echo bp_get_group_name(); ?>" data-basevalue="65" data-basewidth="143"><?php echo $activity; ?></p>
 										<p class="original-copy hidden"><?php echo $activity; ?></p>
 									</div>
+
+									<?php if( current_user_can( 'moderate' ) && in_array( bp_get_group_id(), $private_groups ) ) { ?>
+									<p class="private-membership-indicator"><span class="fa fa-eye-slash"></span> Membership hidden</p>
+									<?php } ?>
 
 								</div>
 
@@ -1586,7 +1600,7 @@ function openlab_is_my_membership_private( $group_id ) {
 	$user_id = bp_loggedin_user_id();
 
 	// Check if the membership is private based on user id and group id
-	$query = $wpdb->get_results( "SELECT `id` FROM $table_name WHERE `user_id` = $user_id AND `group_id` = $group_id" );
+	$query = $wpdb->get_results( "SELECT * FROM $table_name WHERE `user_id` = $user_id AND `group_id` = $group_id" );
 
 	// If there is a record, return true. Otherwise, return false
 	if( $query ) {
@@ -1594,4 +1608,29 @@ function openlab_is_my_membership_private( $group_id ) {
 	}
 
 	return false;
+}
+
+/**
+ * Get user private membership group
+ *  
+ */
+function openlab_get_user_private_membership( $user_id ) {
+	// Skip if user id is missing
+	if( empty( $user_id ) ) {
+		return;
+	}
+
+	global $wpdb;
+	$table_name = $wpdb->prefix . 'private_membership';
+	$query = $wpdb->get_results( "SELECT `group_id` FROM $table_name WHERE `user_id` = $user_id", OBJECT_K);
+
+	$private_groups = array();
+
+	if( $query ) {
+		foreach( $query as $item ) {
+			$private_groups[] = $item->group_id;
+		}
+	}
+
+	return $private_groups;
 }

--- a/wp-content/themes/openlab/style.css
+++ b/wp-content/themes/openlab/style.css
@@ -11380,3 +11380,10 @@ body.single-help .entry-content h6 {
     width: 100%;
   }
 }
+/* Private membership indicator */
+p.private-membership-indicator {
+  margin-top: 15px;
+  font-size: 12px;
+  font-weight: 400;
+  color: #666 !important;
+}

--- a/wp-content/themes/openlab/style.css
+++ b/wp-content/themes/openlab/style.css
@@ -9939,6 +9939,16 @@ input#group-request-send {
 .group-members.group-list .group-item-wrapper .activity {
   font-size: 12px;
 }
+.group-members.group-list .group-item-membership-privacy {
+  margin-top: 15px;
+}
+.group-members.group-list .group-item-membership-privacy label {
+  font-size: 12px;
+  font-weight: 400;
+}
+.group-members.group-list .group-item-membership-privacy label:hover {
+  cursor: pointer;
+}
 .group-manage-members.group-list.group-manage-requests .group-item .group-item-wrapper ul.group-member-actions {
   font-weight: normal;
 }

--- a/wp-content/themes/openlab/style.less
+++ b/wp-content/themes/openlab/style.less
@@ -4343,3 +4343,11 @@ body.single-help {
         width: 100%;
     }
 }
+
+/* Private membership indicator */
+p.private-membership-indicator {
+    margin-top: 15px;
+    font-size: 12px;
+    font-weight: 400;
+    color: #666 !important;
+}

--- a/wp-content/themes/openlab/style.less
+++ b/wp-content/themes/openlab/style.less
@@ -2824,6 +2824,18 @@ input#group-request-send {
                 font-size: 12px;
             }
         }
+        .group-item-membership-privacy {
+            margin-top: 15px;
+
+            label {
+                font-size: 12px;
+                font-weight: 400;
+
+                &:hover {
+                    cursor: pointer;
+                }
+            }
+        }
     }
 }
 .group-manage-members{


### PR DESCRIPTION
- Added checkbox for controlling the membership privacy
- Private groups are hidden when viewing user's profile page
- Private users (except you) are hidden when viewing group's membership page
- Private indicator is added for the mods/admins when viewing user's profile page and group's membership page.

Task ID: 3055